### PR TITLE
Change in provisioning Luci page UI

### DIFF
--- a/luci-mod-provisioning/luasrc/controller/creator/provisioning.lua
+++ b/luci-mod-provisioning/luasrc/controller/creator/provisioning.lua
@@ -23,14 +23,14 @@ function creator_provisioning()
     luci.http.prepare_content("text/html")
     local warning = nil;
     local isProvisioningDaemonRunning = true
+    local isBoardProvisioned = true
     local status = conn:call("provisioning-daemon", "getState", {})
-    if not onboarding.isOnboardingCompleted() then
-        warning = "You must go through onboarding process first in order to start provisioning clickers"
-    elseif status == nil then
+    isBoardProvisioned = onboarding.isOnboardingCompleted()
+    if status == nil then
         isProvisioningDaemonRunning = false
-        warning = "Provisioning daemon is not runnig. Please start it first in order to start provisioning."
+
     end
-    luci.template.render("creator_provisioning/provisioning", {warning=warning, isProvisioningDaemonRunning=isProvisioningDaemonRunning})
+    luci.template.render("creator_provisioning/provisioning", {isBoardProvisioned=isBoardProvisioned, isProvisioningDaemonRunning=isProvisioningDaemonRunning})
 
 end
 

--- a/luci-mod-provisioning/luasrc/view/creator_provisioning/provisioning.htm
+++ b/luci-mod-provisioning/luasrc/view/creator_provisioning/provisioning.htm
@@ -16,9 +16,13 @@
 </div>
 <br />
 
-<% if warning then %>
+<% if not isBoardProvisioned then %>
 <div class="alert alert-danger">
-    <%= warning %>
+    This board hasn't completed onboarding process yet. Please do onboarding first.
+</div>
+<% elseif not isProvisioningDaemonRunning then %>
+<div class="alert alert-danger">
+    Provisioning daemon isn't ranning on this Ci40. Please start it first
 </div>
 <% end %>
 
@@ -60,8 +64,10 @@ function getConnectedClickers(){
 
     });
 }
+<% if (isProvisioningDaemonRunning and isBoardProvisioned) then %>
 getConnectedClickers();
 setInterval("getConnectedClickers()", 2000);
+<% end %>
 
 function startProvisioning(clickerID) {
     $.post('provisioning/start_provisioning',{clickerID : clickerID}, function(data) {


### PR DESCRIPTION
Do not show list of clickers when Ci40 is not yet proviosioned or provisioning daemon is not running

Signed-off-by: Marek Kubiczek <marek.kubiczek@imgtec.com>